### PR TITLE
Make Chrome pushes work

### DIFF
--- a/joincliServer.py
+++ b/joincliServer.py
@@ -37,9 +37,10 @@ class webServer(Handler):
     def do_OPTIONS(self):
         self.send_response(200, "ok")
         self.send_header('Access-Control-Allow-Credentials', 'false')
-        self.send_header('Access-Control-Allow-Origin', 'http://localhost:1820')
+        self.send_header('Access-Control-Allow-Origin', '*')
         self.send_header('Access-Control-Allow-Methods', 'POST, OPTIONS')
         self.send_header("Access-Control-Allow-Headers", "X-Requested-With, Content-type")
+        self.end_headers()
 
 
 def run(server_class=Handler, handler_class=webServer, port=PORT):


### PR DESCRIPTION
The addition of the self.end_headers() enable the server to process chrome pushes from devices on a local network. Yet to test it out on devices from other networks.

The fix works, yet there are some failure notifications (**Not Pushed**) from the Chrome extension, currently not sure why, will investigate when I get some free time.